### PR TITLE
Adding `@derive Jason.Encoder` to all structs

### DIFF
--- a/lib/chalk/client.ex
+++ b/lib/chalk/client.ex
@@ -81,6 +81,7 @@ defmodule Chalk.Client do
     Data structure for an HTTP request with convenience functions.
     """
 
+    @derive Jason.Encoder
     defstruct body: %{}, endpoint: nil, method: nil, opts: %{}
     @type t :: %__MODULE__{body: map, endpoint: String.t(), method: atom, opts: map}
 

--- a/lib/chalk/common.ex
+++ b/lib/chalk/common.ex
@@ -10,6 +10,7 @@ defmodule Chalk.Common do
   end
 
   defmodule ChalkError do
+    @derive Jason.Encoder
     defstruct code: nil, category: nil, message: nil, exception: nil, feature: nil, resolver: nil
 
     @type t :: %__MODULE__{

--- a/lib/chalk/query.ex
+++ b/lib/chalk/query.ex
@@ -5,6 +5,7 @@ defmodule Chalk.Query do
   alias Chalk.Common.ChalkException
 
   defmodule FeatureMeta do
+    @derive Jason.Encoder
     defstruct chosen_resolver_fqn: nil,
               cache_hit: nil
 
@@ -15,6 +16,7 @@ defmodule Chalk.Query do
   end
 
   defmodule FeatureResult do
+    @derive Jason.Encoder
     defstruct error: nil,
               field: nil,
               meta: nil,
@@ -31,6 +33,7 @@ defmodule Chalk.Query do
   end
 
   defmodule QueryMeta do
+    @derive Jason.Encoder
     defstruct execution_duration_s: nil,
               deployment_id: nil,
               query_id: nil,


### PR DESCRIPTION
This will enable all `Chalk` structs to be JSON-serializable.