### PR TITLE
Adding `.formatter.exs` to enable `mix format`

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/chalk/credentials_cache.ex
+++ b/lib/chalk/credentials_cache.ex
@@ -36,7 +36,7 @@ defmodule Chalk.Client.CredentialsCache do
   defp get_access_token(config) do
     params = %{
       client_id: "",
-      client_secret: "",
+      client_secret: ""
     }
 
     res = Chalk.Client.ExchangeCredentials.exchange_credentials(params, config)

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule Chalk.Mixfile do
   defp docs do
     [
       extras: [
-        "LICENSE": [title: "License"],
+        LICENSE: [title: "License"],
         "README.md": [title: "Overview"],
         "parameters.md": [],
         "CHANGELOG.md": []

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,9 +1,7 @@
 defmodule Chalk.Factory do
   @moduledoc false
 
-
   def http_response_body(:error) do
     %{http_code: 200}
   end
-
 end


### PR DESCRIPTION
Per [`mix format` docs](https://hexdocs.pm/mix/main/Mix.Tasks.Format.html).