### PR TITLE
Add ability to specify `deployment_id`

### DIFF
--- a/lib/chalk/client.ex
+++ b/lib/chalk/client.ex
@@ -14,6 +14,10 @@ defmodule Chalk.Client do
 
   # HELPERS
 
+  defp get_base_url(config) do
+    config[:api_server] || "https://api.chalk.ai/"
+  end
+
   defp get_base_middleware(config) do
     [
       {Tesla.Middleware.BaseUrl, get_base_url(config)},
@@ -42,10 +46,6 @@ defmodule Chalk.Client do
     else
       []
     end
-  end
-
-  defp get_base_url(config) do
-    config[:api_server] || "https://api.chalk.ai/"
   end
 
   defp get_middleware(config) do

--- a/lib/chalk/client.ex
+++ b/lib/chalk/client.ex
@@ -27,7 +27,9 @@ defmodule Chalk.Client do
   end
 
   defp get_authentication_middleware(config) do
-    unless Map.get(config, :unauthenticated, false) do
+    unauthenticated? = Map.get(config, :unauthenticated, false)
+
+    unless unauthenticated? do
       [
         {Chalk.Tesla.CredentialsMiddleware,
          %{

--- a/lib/chalk/client.ex
+++ b/lib/chalk/client.ex
@@ -1,5 +1,5 @@
 defmodule Chalk.Client do
-  @version Application.spec(:chalk_elixir, :vsn)
+  @version Chalk.Mixfile.project()[:version]
 
   @spec new(map) :: Tesla.Client.t()
   def new(config \\ %{}) do

--- a/lib/chalk/client.ex
+++ b/lib/chalk/client.ex
@@ -1,18 +1,49 @@
 defmodule Chalk.Client do
+  @version Application.spec(:chalk_elixir, :vsn)
+
   @spec new(map) :: Tesla.Client.t()
+  def new(config \\ %{}) do
+    middleware =
+      get_base_middleware(config) ++
+        get_authentication_middleware(config) ++ get_middleware(config)
+
+    adapter = {get_adapter(config), get_http_options(config)}
+
+    Tesla.client(middleware, adapter)
+  end
+
+  # HELPERS
+
+  defp get_base_middleware(config) do
+    [
+      {Tesla.Middleware.BaseUrl, get_base_url(config)},
+      {Tesla.Middleware.Headers,
+       [
+         {"Content-Type", "application/json"},
+         {"user-agent", "chalk-elixir v#{@version}"}
+       ]},
+      Tesla.Middleware.JSON
+    ]
+  end
+
+  defp get_authentication_middleware(config) do
+    unless Map.get(config, :unauthenticated, false) do
+      [
+        {Chalk.Tesla.CredentialsMiddleware,
+         %{
+           client_id: get_client_id(config),
+           client_secret: get_client_secret(config),
+           api_server: get_base_url(config),
+           deployment_id: get_deployment_id(config)
+         }}
+      ]
+    else
+      []
+    end
+  end
 
   defp get_base_url(config) do
     config[:api_server] || "https://api.chalk.ai/"
-  end
-
-  defp get_metadata(config) do
-    default_metadata = %{
-      service: :chalk
-    }
-
-    metadata = Map.merge(default_metadata, config[:telemetry_metadata] || %{})
-
-    %{metadata: metadata}
   end
 
   defp get_middleware(config) do
@@ -33,36 +64,8 @@ defmodule Chalk.Client do
     Map.get(config, "client_secret", System.get_env("CHALK_CLIENT_SECRET"))
   end
 
-  def new(config \\ %{}) do
-    authentication_middleware =
-      if not Map.get(config, :unauthenticated, false) do
-        [
-          {Chalk.Tesla.CredentialsMiddleware,
-           %{
-             client_id: get_client_id(config),
-             client_secret: get_client_secret(config),
-             api_server: get_base_url(config)
-           }}
-        ]
-      else
-        []
-      end
-
-    middleware =
-      [
-        {Tesla.Middleware.BaseUrl, get_base_url(config)},
-        {Tesla.Middleware.Headers,
-         [
-           {"Content-Type", "application/json"},
-           {"user-agent", "chalk-elixir v0.0.4"}
-         ]},
-        Tesla.Middleware.JSON
-        # {Tesla.Middleware.Telemetry, get_metadata(config)}
-      ] ++ authentication_middleware ++ get_middleware(config)
-
-    adapter = {get_adapter(config), get_http_options(config)}
-
-    Tesla.client(middleware, adapter)
+  defp get_deployment_id(config) do
+    Map.get(config, "deployment_id", System.get_env("DEPLOYMENT_ID"))
   end
 
   defp get_adapter(config) do

--- a/test/lib/chalk_test.exs
+++ b/test/lib/chalk_test.exs
@@ -8,6 +8,26 @@ defmodule ChalkTest do
 
   defmodule Result, do: defstruct([:some])
 
+  describe "Client" do
+    test "has correct setup" do
+      %Tesla.Client{pre: pre} = Client.new()
+
+      {"user-agent", user_agent} =
+        pre
+        |> Enum.find(fn
+          {Tesla.Middleware.Headers, :call, _} -> true
+          _ -> false
+        end)
+        |> then(fn {_, _, [headers]} -> headers end)
+        |> Enum.find(fn
+          {"user-agent", _} -> true
+          _ -> false
+        end)
+
+      assert user_agent =~ Chalk.Mixfile.project()[:version]
+    end
+  end
+
   describe "Chalk send_request/2" do
     setup do
       bypass = Bypass.open()


### PR DESCRIPTION
This enables setting the Chalk deployment for the client to use via:
 - `DEPLOYMENT_ID` environment variable
 - Passing `%{deployment_id: "<deployment_id>"}` in the client `config` map