### PR TITLE
Remove `IO.inspect()` in `Chalk.Tesla.CredentialsMiddleware` and instead return `ChalkCredentialsError`

### DIFF
--- a/lib/chalk/client.ex
+++ b/lib/chalk/client.ex
@@ -5,16 +5,6 @@ defmodule Chalk.Client do
     config[:api_server] || "https://api.chalk.ai/"
   end
 
-  defp get_metadata(config) do
-    default_metadata = %{
-      service: :chalk
-    }
-
-    metadata = Map.merge(default_metadata, config[:telemetry_metadata] || %{})
-
-    %{metadata: metadata}
-  end
-
   defp get_middleware(config) do
     case config[:middleware] || [] do
       middleware when is_list(middleware) ->
@@ -57,7 +47,6 @@ defmodule Chalk.Client do
            {"user-agent", "chalk-elixir v0.0.4"}
          ]},
         Tesla.Middleware.JSON
-        # {Tesla.Middleware.Telemetry, get_metadata(config)}
       ] ++ authentication_middleware ++ get_middleware(config)
 
     adapter = {get_adapter(config), get_http_options(config)}

--- a/lib/chalk/common.ex
+++ b/lib/chalk/common.ex
@@ -22,4 +22,15 @@ defmodule Chalk.Common do
             resolver: String.t()
           }
   end
+
+  defmodule ChalkCredentialsError do
+    @derive Jason.Encoder
+    defstruct detail: nil, trace: nil, stacktrace: nil
+
+    @type t :: %__MODULE__{
+            detail: String.t(),
+            trace: String.t(),
+            stacktrace: String.t()
+          }
+  end
 end

--- a/lib/chalk/credentials_middleware.ex
+++ b/lib/chalk/credentials_middleware.ex
@@ -22,7 +22,6 @@ defmodule Chalk.Tesla.CredentialsMiddleware do
         |> Tesla.run(next)
 
       {:error, detail} ->
-        IO.inspect(detail)
         Tesla.run(env, next)
     end
   end


### PR DESCRIPTION
Instead of `IO.inspect`ing, returning an `:error` tuple like:

```elixir
{:error,
  %Chalk.Common.ChalkCredentialsError{
    detail: "Failed to parse entity",
    stacktrace:
      "[{Process, :info, 2, [file: 'lib/process.ex', line: 773]}, {Chalk.Tesla.CredentialsMiddleware, :call, 3, [file: 'lib/chalk/credentials_middleware.ex', line: 27]}, {Tesla.Middleware.JSON, :call, 3, [file: 'lib/tesla/middleware/json.ex', line: 54]}, {Chalk.Query, :request_operation, 3, [file: 'lib/chalk/query.ex', line: 80]}, {ChalkTest, :\"test Chalk Query can roundtrip a query for an input feature\", 1, [file: 'test/lib/chalk_test.exs', line: 42]}, {ExUnit.Runner, :exec_test, 1, [file: 'lib/ex_unit/runner.ex', line: 500]}, {:timer, :tc, 1, [file: 'timer.erl', line: 235]}, {ExUnit.Runner, :\"-spawn_test_monitor/4-fun-1-\", 4, [file: 'lib/ex_unit/runner.ex', line: 451]}]",
    trace: "clf2lvv9d002k0ss6cwu5m7zt"
  }}
```