### PR TITLE
Fix `case` handling in `Chalk.Tesla.CredentialsMiddleware.call/3`

### DIFF
--- a/lib/chalk/common.ex
+++ b/lib/chalk/common.ex
@@ -25,11 +25,10 @@ defmodule Chalk.Common do
 
   defmodule ChalkCredentialsError do
     @derive Jason.Encoder
-    defstruct detail: nil, trace: nil, stacktrace: nil
+    defstruct error: nil, stacktrace: nil
 
     @type t :: %__MODULE__{
-            detail: String.t(),
-            trace: String.t(),
+            error: String.t(),
             stacktrace: String.t()
           }
   end

--- a/lib/chalk/credentials_middleware.ex
+++ b/lib/chalk/credentials_middleware.ex
@@ -33,13 +33,12 @@ defmodule Chalk.Tesla.CredentialsMiddleware do
         |> Tesla.put_headers(headers)
         |> Tesla.run(next)
 
-      {:error, %{"detail" => detail, "trace" => trace}} ->
+      {:error, error} ->
         {:current_stacktrace, stacktrace} = Process.info(self(), :current_stacktrace)
 
         {:error,
          %ChalkCredentialsError{
-           detail: detail,
-           trace: trace,
+           error: inspect(error),
            stacktrace: inspect(stacktrace)
          }}
     end


### PR DESCRIPTION
Updating this to handle all generic errors rather than matching on one specific error body.