### PR TITLE
Properly pass `deployment_id` in request params

### DIFF
--- a/lib/chalk/client.ex
+++ b/lib/chalk/client.ex
@@ -1,6 +1,4 @@
 defmodule Chalk.Client do
-  @moduledoc false
-
   @version Chalk.Mixfile.project()[:version]
 
   @spec new(map) :: Tesla.Client.t()

--- a/lib/chalk/client.ex
+++ b/lib/chalk/client.ex
@@ -1,4 +1,6 @@
 defmodule Chalk.Client do
+  @moduledoc false
+
   @version Chalk.Mixfile.project()[:version]
 
   @spec new(map) :: Tesla.Client.t()
@@ -43,18 +45,17 @@ defmodule Chalk.Client do
   defp get_authentication_middleware(config) do
     unauthenticated? = Map.get(config, :unauthenticated, false)
 
-    unless unauthenticated? do
+    if unauthenticated? do
+      []
+    else
       [
         {Chalk.Tesla.CredentialsMiddleware,
          %{
            client_id: get_client_id(config),
            client_secret: get_client_secret(config),
-           api_server: get_base_url(config),
-           deployment_id: get_deployment_id(config)
+           api_server: get_base_url(config)
          }}
       ]
-    else
-      []
     end
   end
 
@@ -69,15 +70,15 @@ defmodule Chalk.Client do
   end
 
   defp get_client_id(config) do
-    Map.get(config, "client_id", System.get_env("CHALK_CLIENT_ID"))
+    Map.get(config, :client_id, System.get_env("CHALK_CLIENT_ID"))
   end
 
   defp get_client_secret(config) do
-    Map.get(config, "client_secret", System.get_env("CHALK_CLIENT_SECRET"))
+    Map.get(config, :client_secret, System.get_env("CHALK_CLIENT_SECRET"))
   end
 
   defp get_deployment_id(config) do
-    Map.get(config, "deployment_id", System.get_env("DEPLOYMENT_ID"))
+    Map.get(config, :deployment_id, System.get_env("DEPLOYMENT_ID"))
   end
 
   defp get_adapter(config) do

--- a/lib/chalk/query.ex
+++ b/lib/chalk/query.ex
@@ -1,14 +1,10 @@
 defmodule Chalk.Query do
-  @moduledoc false
-
   alias Chalk.Client
   alias Chalk.Client.Request
   alias Chalk.Common.ChalkError
   alias Chalk.Common.ChalkException
 
   defmodule FeatureMeta do
-    @moduledoc false
-
     @derive Jason.Encoder
     defstruct cache_hit: nil,
               chosen_resolver_fqn: nil,
@@ -24,8 +20,6 @@ defmodule Chalk.Query do
   end
 
   defmodule FeatureResult do
-    @moduledoc false
-
     @derive Jason.Encoder
     defstruct error: nil,
               field: nil,
@@ -45,8 +39,6 @@ defmodule Chalk.Query do
   end
 
   defmodule QueryMeta do
-    @moduledoc false
-
     @derive Jason.Encoder
     defstruct deployment_id: nil,
               environment_id: nil,
@@ -68,8 +60,6 @@ defmodule Chalk.Query do
   end
 
   defmodule OnlineQueryResponse do
-    @moduledoc false
-
     @derive Jason.Encoder
     defstruct data: [],
               errors: [],
@@ -87,10 +77,19 @@ defmodule Chalk.Query do
   """
   @spec online(
           %{
-            required(:inputs) => [String.t()],
+            required(:inputs) => %{
+              String.t() => String.t()
+            },
             required(:outputs) => [String.t()],
-            optional(:query_name) => String.t(),
-            optional(:deployment_id) => String.t()
+            optional(:staleness) => %{
+              String.t() => String.t()
+            },
+            optional(:context) => %{
+              optional(:environment) => String.t(),
+              optional(:tags) => [String.t()]
+            },
+            optional(:deployment_id) => String.t(),
+            optional(:query_name) => String.t()
           },
           map()
         ) :: {:ok, OnlineQueryResponse.t()} | {:error, any()}


### PR DESCRIPTION
The way we were passing `deployment_id` in the headers was not actually setting the `deployment_id`: it actually needs to be in the request params.

<img width="863" alt="image" src="https://user-images.githubusercontent.com/26069404/228600714-0e27b92e-befb-4f11-babe-e3910d7f0849.png">

---

This PR also makes the change to only use atom keys in config.