### PR TITLE
Adding `@derive Jason.Encoder` to `Chalk.Common.ChalkException`

### DIFF
--- a/lib/chalk/common.ex
+++ b/lib/chalk/common.ex
@@ -1,5 +1,6 @@
 defmodule Chalk.Common do
   defmodule ChalkException do
+    @derive Jason.Encoder
     defstruct kind: nil, message: nil, stacktrace: nil
 
     @type t :: %__MODULE__{

--- a/lib/chalk/query.ex
+++ b/lib/chalk/query.ex
@@ -126,7 +126,11 @@ defmodule Chalk.Query do
             meta: %FeatureMeta{}
           }
         ],
-        errors: [%ChalkError{}],
+        errors: [
+          %ChalkError{
+            exception: %ChalkException{}
+          }
+        ],
         meta: %QueryMeta{}
       }
     })

--- a/test/lib/chalk_test.exs
+++ b/test/lib/chalk_test.exs
@@ -84,18 +84,21 @@ defmodule ChalkTest do
 
     test "can pass credentials as an argument" do
       assert 1 ==
-        Chalk.Query.online(%{
-          inputs: %{
-            "user.id": 1
-          },
-          outputs: [
-            "user.id",
-            "user.full_name"
-          ]
-        }, %{
-            client_id: "my-client",
-            secret: "my-secret"
-        })
+               Chalk.Query.online(
+                 %{
+                   inputs: %{
+                     "user.id": 1
+                   },
+                   outputs: [
+                     "user.id",
+                     "user.full_name"
+                   ]
+                 },
+                 %{
+                   client_id: "my-client",
+                   secret: "my-secret"
+                 }
+               )
     end
   end
 


### PR DESCRIPTION
Looks like we missed this module/struct, so it was getting deserialized as a map rather than a `ChalkException`.