### PR TITLE
fix example config error and document deployment_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The credentials can also be passed directly when invoking the client.
 | Variable                                | Kind         | Description                                                                                                                                      |
 | --------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `CHALK_CLIENT_ID`          | **Required** | Your Chalk client ID. You must specify this environment variable or pass an explicit `client_id` value when constructing your ChalkClient         |
-| `CHALK_CLIENT_SECRET`      | **Required** | Your Chalk client secret. You must specify this environment variable or pass an explicit `secret` value when constructing your ChalkClient |
+| `CHALK_CLIENT_SECRET`      | **Required** | Your Chalk client secret. You must specify this environment variable or pass an explicit `client_secret` value when constructing your ChalkClient |
 | `DEPLOYMENT_ID` | Optional     | The ID of the deployment. You must specify this environment variable or pass an explicit `deployment_id` value when constructing your ChalkClient                   |
 
 You can find relevant variables to use with your Chalk Client by

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ The credentials can also be passed directly when invoking the client.
         ]
     }, %{    
         client_id: THE_CLIENT_ID,
-        secret: THE_SECRET
+        client_secret: THE_SECRET
     })
 ```
+
+### Supported environment variables
+
+| Variable                                | Kind         | Description                                                                                                                                      |
+| --------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `CHALK_CLIENT_ID`          | **Required** | Your Chalk client ID. You must specify this environment variable or pass an explicit `client_id` value when constructing your ChalkClient         |
+| `CHALK_CLIENT_SECRET`      | **Required** | Your Chalk client secret. You must specify this environment variable or pass an explicit `secret` value when constructing your ChalkClient |
+| `DEPLOYMENT_ID` | Optional     | The ID of the deployment. You must specify this environment variable or pass an explicit `deployment_id` value when constructing your ChalkClient                   |
+
+You can find relevant variables to use with your Chalk Client by
+running `chalk config` with the Chalk command line tool.


### PR DESCRIPTION
I've started fiddling a bit with the Elixir client and I noticed that the sample config has an error. `client.ex` is going to look for a `client_secret` key, not a `secret` key.

I went ahead and updated that. I also noticed that this client accepts `DEPLOYMENT_ID` but it isn't documented. I added a table of accepted env vars like the one that appears at the end of the TS client README.

It would be cool if the Elixir client accepted all the env vars that the TS client does. I might make a PR to check for those when parsing the config as well.