### PR TITLE
Let client use `CHALK_API_SERVER` env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The credentials can also be passed directly when invoking the client.
 | --------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `CHALK_CLIENT_ID`          | **Required** | Your Chalk client ID. You must specify this environment variable or pass an explicit `client_id` value when constructing your ChalkClient         |
 | `CHALK_CLIENT_SECRET`      | **Required** | Your Chalk client secret. You must specify this environment variable or pass an explicit `secret` value when constructing your ChalkClient |
+| `CHALK_API_SERVER`         | Optional     | The API server that the client will communicate with. This defaults to https://api.chalk.ai which should be sufficient for most consumers. You can also pass an explicit `api_server` value when constructing your ChalkClient       |
 | `DEPLOYMENT_ID` | Optional     | The ID of the deployment. You must specify this environment variable or pass an explicit `deployment_id` value when constructing your ChalkClient                   |
 
 You can find relevant variables to use with your Chalk Client by

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The credentials can also be passed directly when invoking the client.
 | Variable                                | Kind         | Description                                                                                                                                      |
 | --------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `CHALK_CLIENT_ID`          | **Required** | Your Chalk client ID. You must specify this environment variable or pass an explicit `client_id` value when constructing your ChalkClient         |
-| `CHALK_CLIENT_SECRET`      | **Required** | Your Chalk client secret. You must specify this environment variable or pass an explicit `secret` value when constructing your ChalkClient |
+| `CHALK_CLIENT_SECRET`      | **Required** | Your Chalk client secret. You must specify this environment variable or pass an explicit `client_secret` value when constructing your ChalkClient |
 | `CHALK_API_SERVER`         | Optional     | The API server that the client will communicate with. This defaults to https://api.chalk.ai which should be sufficient for most consumers. You can also pass an explicit `api_server` value when constructing your ChalkClient       |
 | `DEPLOYMENT_ID` | Optional     | The ID of the deployment. You must specify this environment variable or pass an explicit `deployment_id` value when constructing your ChalkClient                   |
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ The credentials can also be passed directly when invoking the client.
         ]
     }, %{    
         client_id: THE_CLIENT_ID,
-        secret: THE_SECRET
+        client_secret: THE_SECRET
     })
 ```
+
+### Supported environment variables
+
+| Variable                                | Kind         | Description                                                                                                                                      |
+| --------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `CHALK_CLIENT_ID`          | **Required** | Your Chalk client ID. You must specify this environment variable or pass an explicit `client_id` value when constructing your ChalkClient         |
+| `CHALK_CLIENT_SECRET`      | **Required** | Your Chalk client secret. You must specify this environment variable or pass an explicit `secret` value when constructing your ChalkClient |
+| `DEPLOYMENT_ID` | Optional     | The ID of the deployment. You must specify this environment variable or pass an explicit `deployment_id` value when constructing your ChalkClient                   |
+
+You can find relevant variables to use with your Chalk Client by
+running `chalk config` with the Chalk command line tool.

--- a/lib/chalk/client.ex
+++ b/lib/chalk/client.ex
@@ -15,7 +15,7 @@ defmodule Chalk.Client do
   # HELPERS
 
   defp get_base_url(config) do
-    config[:api_server] || "https://api.chalk.ai/"
+    config[:api_server] || System.get_env("CHALK_API_SERVER") || "https://api.chalk.ai/"
   end
 
   defp get_base_middleware(config) do


### PR DESCRIPTION
I'm adding this so that the Elixir client matches the behavior of other clients like the TS client. That client allows the user to pass in many more env vars. I should add a test for this as well.